### PR TITLE
fix: board/square bug squashing

### DIFF
--- a/src/components/board.tsx
+++ b/src/components/board.tsx
@@ -11,18 +11,24 @@ interface AlertProps {
 function Alert({ tie, winner }: AlertProps) {
   if (winner) {
     return (
-      <div className="flex gap-x-4">
-        <strong>Winner</strong> {winner}
-        <button className="">New Game</button>
+      <div className="flex gap-x-4 justify-between bg-green-950 rounded-md p-4 mb-4">
+        <div className="text-white">
+          <strong className="font-normal py-1">Winner:</strong> {winner}
+        </div>
+        <button className="cursor-pointer text-green-300 hover:text-green-200">
+          New Game
+        </button>
       </div>
     );
   }
 
   if (tie) {
     return (
-      <div className="flex gap-x-4">
-        <strong style={{ padding: "1px 0" }}>Tied game</strong>
-        <button className="">New Game</button>
+      <div className="flex gap-x-4 justify-between bg-green-950 rounded-md p-4 mb-4">
+        <strong className="font-normal text-white">Tied game</strong>
+        <button className="cursor-pointer text-green-300 hover:text-green-200">
+          New Game
+        </button>
       </div>
     );
   }

--- a/src/components/board.tsx
+++ b/src/components/board.tsx
@@ -8,16 +8,28 @@ interface AlertProps {
   winner: Cell;
 }
 
+function RenderResetButton(dispatch: (action: any) => void) {
+  return (
+    <button
+      className="cursor-pointer text-green-300 hover:text-green-200"
+      onClick={() => {
+        dispatch({ type: "RESET", data: null });
+      }}
+    >
+      New game
+    </button>
+  );
+}
+
 function Alert({ tie, winner }: AlertProps) {
+  const { dispatch } = useContext(GameContext);
   if (winner) {
     return (
       <div className="flex gap-x-4 justify-between bg-green-950 rounded-md p-4 mb-4">
         <div className="text-white">
           <strong className="font-normal py-1">Winner:</strong> {winner}
         </div>
-        <button className="cursor-pointer text-green-300 hover:text-green-200">
-          New Game
-        </button>
+        {RenderResetButton(dispatch)}
       </div>
     );
   }
@@ -26,9 +38,7 @@ function Alert({ tie, winner }: AlertProps) {
     return (
       <div className="flex gap-x-4 justify-between bg-green-950 rounded-md p-4 mb-4">
         <strong className="font-normal text-white">Tied game</strong>
-        <button className="cursor-pointer text-green-300 hover:text-green-200">
-          New Game
-        </button>
+        {RenderResetButton(dispatch)}
       </div>
     );
   }

--- a/src/components/square.tsx
+++ b/src/components/square.tsx
@@ -16,7 +16,7 @@ export function Square({
   const {
     dispatch,
     state: {
-      data: { winningCells, gameType },
+      data: { winningCells, gameType, winner, tie },
     },
   } = useContext(GameContext);
 
@@ -38,17 +38,19 @@ export function Square({
     <div
       className="square"
       onClick={() => {
-        dispatch({ type: "CELL_CLICK", data: { x: rowCount, y: cellCount } });
+        if (!value && !tie && !winner) {
+          dispatch({ type: "CELL_CLICK", data: { x: rowCount, y: cellCount } });
 
-        if (gameType === "PVC") {
-          // timeout here so it's not too aggressive to the user
-          setTimeout(() => {
-            dispatch({ type: "COMPUTER_PLAY", data: null });
-          }, 500);
+          if (gameType === "PVC") {
+            // timeout here so it's not too aggressive to the user
+            setTimeout(() => {
+              dispatch({ type: "COMPUTER_PLAY", data: null });
+            }, 500);
+          }
         }
       }}
       style={{
-        cursor: "pointer",
+        cursor: `${!value && !tie && !winner ? "pointer" : "default"}`,
         backgroundColor,
       }}
     >


### PR DESCRIPTION
This PR fixes these bugs:

1. Winner/tie alert styling
2. Reset/New Game button doesn’t work
3. Clicking the same cell twice flips it
